### PR TITLE
iOS 13 Dynamic colors

### DIFF
--- a/TXTStyleCell.m
+++ b/TXTStyleCell.m
@@ -7,7 +7,7 @@
 
     if (self) {
         UILabel *label = [[UILabel alloc] initWithFrame:self.contentView.frame];
-        [label setTextColor:[UIColor whiteColor]];
+        [label setTextColor:[UIColor labelColor]];
         [label setTextAlignment:NSTextAlignmentCenter];
         [label setFont:[UIFont systemFontOfSize:16]];
 

--- a/TXTStyleSelectionController.m
+++ b/TXTStyleSelectionController.m
@@ -73,7 +73,7 @@
     blurMask.layer.cornerRadius = kCornerRadius;
     blurMask.clipsToBounds = YES;
 
-    UIBlurEffect *blur = [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark];
+    UIBlurEffect *blur = [UIBlurEffect effectWithStyle:UIBlurEffectStyleSystemChromeMaterial];
     UIVisualEffectView *blurView = [[UIVisualEffectView alloc] initWithEffect:blur];
     blurView.frame = blurMask.bounds;
     blurView.layer.masksToBounds = NO;
@@ -114,7 +114,7 @@
 
     [UIView animateWithDuration:0.1
                      animations:^{
-                         [cell setBackgroundColor:[UIColor colorWithRed:1.00 green:0.18 blue:0.33 alpha:1.0f]];
+                         [cell setBackgroundColor:[UIColor systemPinkColor]];
                      }
                      completion:^(BOOL finished) {
                         [self dismissViewControllerAnimated:YES completion:nil];
@@ -140,7 +140,7 @@
 
 - (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath {
     if ([indexPath isEqual:selectedIndexPath]) {
-        [cell setBackgroundColor:[UIColor colorWithRed:1.00 green:0.18 blue:0.33 alpha:1.0f]];
+        [cell setBackgroundColor:[UIColor systemPinkColor]];
     } else {
         [cell setBackgroundColor:[UIColor clearColor]];
     }


### PR DESCRIPTION
Since this is built for iOS 13 and up, the pop-up collection should probably not be always styled dark.

- changed blur effect to the system chrome material
- changed label color to the system label color
- changed selection color to the system pink color

Untested. Will probably need some kind of `@available` check for clang to be happy.